### PR TITLE
Make heat inventory plugin executable

### DIFF
--- a/plugins/inventory/heat.py
+++ b/plugins/inventory/heat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 DOCUMENTATION = '''
 ---
 inventory: heat


### PR DESCRIPTION
Inventory plugins should be executable. Changing permissions and adding
python #!.
